### PR TITLE
Arrow2, Cache Storage and Object Storage

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,0 @@
-[target.aarch64-unknown-linux-gnu]
-linker = "aarch64-linux-gnu-gcc"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -716,6 +716,7 @@ dependencies = [
  "log",
  "moka",
  "object",
+ "object_store",
  "prost",
  "prost-types",
  "rustc-demangle",
@@ -785,12 +786,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -798,6 +815,34 @@ name = "futures-core"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "futures-sink"
@@ -817,10 +862,16 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "pin-utils",
+ "slab",
 ]
 
 [[package]]
@@ -1494,6 +1545,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "object_store"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6eb4c22c6154a1e759d7099f9ffad7cc5ef8245f9efbab4a41b92623079c82f3"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "chrono",
+ "futures",
+ "humantime",
+ "itertools",
+ "parking_lot",
+ "percent-encoding",
+ "snafu",
+ "tokio",
+ "tracing",
+ "url",
+ "walkdir",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1849,6 +1921,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1925,6 +2006,27 @@ name = "smallvec"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+
+[[package]]
+name = "snafu"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "223891c85e2a29c3fe8fb900c1fae5e69c2e42415e3177752e8718475efa5019"
+dependencies = [
+ "snafu-derive",
+]
+
+[[package]]
+name = "snafu-derive"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03c3c6b7927ffe7ecaa769ee0e3994da3b8cafc8f444578982c83ecb161af917"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "socket2"
@@ -2358,6 +2460,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2471,6 +2583,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+dependencies = [
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,7 +31,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
- "const-random",
  "getrandom",
  "once_cell",
  "version_check",
@@ -118,217 +117,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c95c10ba0b00a02636238b814946408b1322d5ac4760326e6fb8ec956d85775"
 
 [[package]]
-name = "arrow"
-version = "53.2.0"
+name = "arrow2"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4caf25cdc4a985f91df42ed9e9308e1adbcd341a31a72605c697033fcef163e3"
-dependencies = [
- "arrow-arith",
- "arrow-array",
- "arrow-buffer",
- "arrow-cast",
- "arrow-csv",
- "arrow-data",
- "arrow-ipc",
- "arrow-json",
- "arrow-ord",
- "arrow-row",
- "arrow-schema",
- "arrow-select",
- "arrow-string",
-]
-
-[[package]]
-name = "arrow-arith"
-version = "53.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91f2dfd1a7ec0aca967dfaa616096aec49779adc8eccec005e2f5e4111b1192a"
-dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
- "chrono",
- "half",
- "num",
-]
-
-[[package]]
-name = "arrow-array"
-version = "53.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d39387ca628be747394890a6e47f138ceac1aa912eab64f02519fed24b637af8"
+checksum = "963fef509b757bcbbf9e5ffa23bcb345614d99f4f6f531f97417b27b8604d389"
 dependencies = [
  "ahash",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
+ "bytemuck",
  "chrono",
- "half",
+ "comfy-table",
+ "dyn-clone",
+ "either",
+ "ethnum",
+ "foreign_vec",
+ "getrandom",
+ "hash_hasher",
  "hashbrown 0.14.5",
- "num",
-]
-
-[[package]]
-name = "arrow-buffer"
-version = "53.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e51e05228852ffe3eb391ce7178a0f97d2cf80cc6ef91d3c4a6b3cb688049ec"
-dependencies = [
- "bytes",
- "half",
- "num",
-]
-
-[[package]]
-name = "arrow-cast"
-version = "53.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d09aea56ec9fa267f3f3f6cdab67d8a9974cbba90b3aa38c8fe9d0bb071bd8c1"
-dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
- "arrow-select",
- "atoi",
- "base64",
- "chrono",
- "half",
- "lexical-core",
- "num",
- "ryu",
-]
-
-[[package]]
-name = "arrow-csv"
-version = "53.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c07b5232be87d115fde73e32f2ca7f1b353bff1b44ac422d3c6fc6ae38f11f0d"
-dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-cast",
- "arrow-data",
- "arrow-schema",
- "chrono",
- "csv",
- "csv-core",
- "lazy_static",
- "lexical-core",
- "regex",
-]
-
-[[package]]
-name = "arrow-data"
-version = "53.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b98ae0af50890b494cebd7d6b04b35e896205c1d1df7b29a6272c5d0d0249ef5"
-dependencies = [
- "arrow-buffer",
- "arrow-schema",
- "half",
- "num",
-]
-
-[[package]]
-name = "arrow-ipc"
-version = "53.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ed91bdeaff5a1c00d28d8f73466bcb64d32bbd7093b5a30156b4b9f4dba3eee"
-dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-cast",
- "arrow-data",
- "arrow-schema",
- "flatbuffers",
-]
-
-[[package]]
-name = "arrow-json"
-version = "53.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0471f51260a5309307e5d409c9dc70aede1cd9cf1d4ff0f0a1e8e1a2dd0e0d3c"
-dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-cast",
- "arrow-data",
- "arrow-schema",
- "chrono",
- "half",
- "indexmap 2.6.0",
- "lexical-core",
- "num",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "arrow-ord"
-version = "53.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2883d7035e0b600fb4c30ce1e50e66e53d8656aa729f2bfa4b51d359cf3ded52"
-dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
- "arrow-select",
- "half",
- "num",
-]
-
-[[package]]
-name = "arrow-row"
-version = "53.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "552907e8e587a6fde4f8843fd7a27a576a260f65dab6c065741ea79f633fc5be"
-dependencies = [
- "ahash",
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
- "half",
-]
-
-[[package]]
-name = "arrow-schema"
-version = "53.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "539ada65246b949bd99ffa0881a9a15a4a529448af1a07a9838dd78617dafab1"
-
-[[package]]
-name = "arrow-select"
-version = "53.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6259e566b752da6dceab91766ed8b2e67bf6270eb9ad8a6e07a33c1bede2b125"
-dependencies = [
- "ahash",
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
- "num",
-]
-
-[[package]]
-name = "arrow-string"
-version = "53.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3179ccbd18ebf04277a095ba7321b93fd1f774f18816bd5f6b3ce2f594edb6c"
-dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
- "arrow-select",
- "memchr",
- "num",
- "regex",
- "regex-syntax",
+ "num-traits",
+ "rustc_version",
+ "simdutf8",
 ]
 
 [[package]]
@@ -350,7 +157,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -361,16 +168,7 @@ checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
-]
-
-[[package]]
-name = "atoi"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
-dependencies = [
- "num-traits",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -464,12 +262,6 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "bitflags"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
@@ -479,6 +271,26 @@ name = "bumpalo"
 version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+
+[[package]]
+name = "bytemuck"
+version = "1.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b37c88a63ffd85d15b406896cc343916d7cf57838a847b3a6f2ca5d39a5695a"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcfcc3cd946cb52f0bbfdbbcfa2f4e24f75ebb6c0e1002f7c25904fada18b9ec"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
 
 [[package]]
 name = "byteorder"
@@ -549,23 +361,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "const-random"
-version = "0.1.18"
+name = "comfy-table"
+version = "6.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+checksum = "7e959d788268e3bf9d35ace83e81b124190378e4c91c9067524675e33394b8ba"
 dependencies = [
- "const-random-macro",
-]
-
-[[package]]
-name = "const-random-macro"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
-dependencies = [
- "getrandom",
- "once_cell",
- "tiny-keccak",
+ "strum",
+ "strum_macros",
+ "unicode-width",
 ]
 
 [[package]]
@@ -617,33 +420,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
 
 [[package]]
-name = "crunchy"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
-
-[[package]]
-name = "csv"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac574ff4d437a7b5ad237ef331c17ccca63c46479e5b5453eb8e10bb99a759fe"
-dependencies = [
- "csv-core",
- "itoa",
- "ryu",
- "serde",
-]
-
-[[package]]
-name = "csv-core"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5efa2b3d7902f4b634a20cae3c9c4e6209dc4779feb6863329607560143efa70"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -651,8 +427,14 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.87",
 ]
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
 
 [[package]]
 name = "either"
@@ -700,12 +482,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ethnum"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b90ca2580b73ab6a1f724b76ca11ab632df820fd6040c336200d2c1df7b3c82c"
+
+[[package]]
 name = "evprofiler"
 version = "0.1.0"
 dependencies = [
  "addr2line",
  "anyhow",
- "arrow",
+ "arrow2",
  "async-stream",
  "bincode",
  "chrono",
@@ -751,16 +539,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
-name = "flatbuffers"
-version = "24.3.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8add37afff2d4ffa83bc748a70b4b1370984f6980768554182424ef71447c35f"
-dependencies = [
- "bitflags 1.3.2",
- "rustc_version",
-]
-
-[[package]]
 name = "flate2"
 version = "1.0.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -775,6 +553,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foreign_vec"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee1b05cbd864bcaecbd3455d6d967862d446e4ebfc3c2e5e5b9841e53cba6673"
 
 [[package]]
 name = "form_urlencoded"
@@ -841,7 +625,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -918,15 +702,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "half"
-version = "2.4.1"
+name = "hash_hasher"
+version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888"
-dependencies = [
- "cfg-if",
- "crunchy",
- "num-traits",
-]
+checksum = "74721d007512d0cb3338cd20f0654ac913920061a4c4d0d8708edb3f2a698c0c"
 
 [[package]]
 name = "hashbrown"
@@ -939,12 +718,21 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+]
 
 [[package]]
 name = "hashbrown"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
+
+[[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "heck"
@@ -1201,7 +989,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1282,80 +1070,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "lexical-core"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0431c65b318a590c1de6b8fd6e72798c92291d27762d94c9e6c37ed7a73d8458"
-dependencies = [
- "lexical-parse-float",
- "lexical-parse-integer",
- "lexical-util",
- "lexical-write-float",
- "lexical-write-integer",
-]
-
-[[package]]
-name = "lexical-parse-float"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb17a4bdb9b418051aa59d41d65b1c9be5affab314a872e5ad7f06231fb3b4e0"
-dependencies = [
- "lexical-parse-integer",
- "lexical-util",
- "static_assertions",
-]
-
-[[package]]
-name = "lexical-parse-integer"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5df98f4a4ab53bf8b175b363a34c7af608fe31f93cc1fb1bf07130622ca4ef61"
-dependencies = [
- "lexical-util",
- "static_assertions",
-]
-
-[[package]]
-name = "lexical-util"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85314db53332e5c192b6bca611fb10c114a80d1b831ddac0af1e9be1b9232ca0"
-dependencies = [
- "static_assertions",
-]
-
-[[package]]
-name = "lexical-write-float"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e7c3ad4e37db81c1cbe7cf34610340adc09c322871972f74877a712abc6c809"
-dependencies = [
- "lexical-util",
- "lexical-write-integer",
- "static_assertions",
-]
-
-[[package]]
-name = "lexical-write-integer"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb89e9f6958b83258afa3deed90b5de9ef68eef090ad5086c791cd2345610162"
-dependencies = [
- "lexical-util",
- "static_assertions",
-]
-
-[[package]]
 name = "libc"
 version = "0.2.161"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9489c2807c139ffd9c1794f4af0ebe86a828db53ecdc7fea2111d0fed085d1"
-
-[[package]]
-name = "libm"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1460,77 +1178,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
 
 [[package]]
-name = "num"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
-dependencies = [
- "num-bigint",
- "num-complex",
- "num-integer",
- "num-iter",
- "num-rational",
- "num-traits",
-]
-
-[[package]]
-name = "num-bigint"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
-dependencies = [
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-complex"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "num-integer"
-version = "0.1.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "num-iter"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
-dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-rational"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
-dependencies = [
- "num-bigint",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
- "libm",
 ]
 
 [[package]]
@@ -1627,7 +1280,7 @@ checksum = "3c0f5fad0874fc7abcd4d750e76917eaebbecaa2c20bde22e1dbeeba8beb758c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1658,7 +1311,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64d1ec885c64d0457d564db4ec299b2dae3f9c02808b8ad9c3a089c591b18033"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1687,7 +1340,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c1318b19085f08681016926435853bbf7858f9c082d0999b80550ff5d9abe15"
 dependencies = [
  "bytes",
- "heck",
+ "heck 0.5.0",
  "itertools",
  "log",
  "multimap",
@@ -1697,7 +1350,7 @@ dependencies = [
  "prost",
  "prost-types",
  "regex",
- "syn",
+ "syn 2.0.87",
  "tempfile",
 ]
 
@@ -1711,7 +1364,7 @@ dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1783,7 +1436,7 @@ version = "11.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ab240315c661615f2ee9f0f2cd32d5a7343a84d5ebcccb99d46e6637565e7b0"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags",
 ]
 
 [[package]]
@@ -1792,7 +1445,7 @@ version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b6dfecf2c74bce2466cabf93f6664d6998a69eb21e39f4207930065b27b771f"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags",
 ]
 
 [[package]]
@@ -1860,7 +1513,7 @@ version = "0.38.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7f649912bc1495e167a6edee79151c84b1bad49748cb4f1f1167f459f6224f6"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1958,19 +1611,7 @@ checksum = "ad1e866f866923f252f05c889987993144fb74e722403468a4ebd70c3cd756c0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
-]
-
-[[package]]
-name = "serde_json"
-version = "1.0.132"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d726bfaff4b320266d395898905d0eba0345aae23b54aee3a737e260fd46db03"
-dependencies = [
- "itoa",
- "memchr",
- "ryu",
- "serde",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1991,6 +1632,12 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "slab"
@@ -2022,10 +1669,10 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03c3c6b7927ffe7ecaa769ee0e3994da3b8cafc8f444578982c83ecb161af917"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -2057,10 +1704,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "strum"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
+
+[[package]]
+name = "strum_macros"
+version = "0.24.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
 
 [[package]]
 name = "syn"
@@ -2093,7 +1770,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -2132,16 +1809,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
-]
-
-[[package]]
-name = "tiny-keccak"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
-dependencies = [
- "crunchy",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -2178,7 +1846,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -2261,7 +1929,7 @@ dependencies = [
  "prost-build",
  "prost-types",
  "quote",
- "syn",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -2329,7 +1997,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -2385,6 +2053,12 @@ name = "unicode-ident"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unsafe-libyaml"
@@ -2506,7 +2180,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.87",
  "wasm-bindgen-shared",
 ]
 
@@ -2528,7 +2202,7 @@ checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.87",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -2788,7 +2462,7 @@ checksum = "28cc31741b18cb6f1d5ff12f5b7523e3d6eb0852bbbad19d73905511d9849b95"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.87",
  "synstructure",
 ]
 
@@ -2810,7 +2484,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -2830,7 +2504,7 @@ checksum = "0ea7b4a3637ea8669cedf0f1fd5c286a17f3de97b8dd5a70a6c167a1730e63a5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.87",
  "synstructure",
 ]
 
@@ -2859,5 +2533,5 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.87",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ bincode = "1.3.3"
 serde = {version = "1.0.215", features = ["derive"]}
 anyhow = "1.0.93"
 moka = { version = "0.12.8", features = ["sync"] }
+object_store = "0.11.1"
 
 [build-dependencies]
 tonic-build = "0.12.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ tokio-stream = "0.1.16"
 log = "0.4.22"
 colog = "1.3.0"
 async-stream = "0.3.6"
-arrow = "53.2.0"
 flate2 = "1.0"
 url = "2.5.3"
 ureq = "2.10.1"
@@ -29,6 +28,7 @@ serde = {version = "1.0.215", features = ["derive"]}
 anyhow = "1.0.93"
 moka = { version = "0.12.8", features = ["sync"] }
 object_store = "0.11.1"
+arrow2 = {version = "0.18.0", features = ["io_print"]}
 
 [build-dependencies]
 tonic-build = "0.12.3"

--- a/src/debuginfo_store/debuginfod.rs
+++ b/src/debuginfo_store/debuginfod.rs
@@ -78,17 +78,15 @@ impl DebugInfod {
                 response
                     .into_reader()
                     .read_to_end(&mut content)
-                    .with_context(|| {
-                        format!("Failed to read response from the debuginfod server")
-                    })?;
+                    .with_context(|| "Failed to read response from the debuginfod server")?;
 
-                let _ = self.bucket.put(&path, content.clone().into());
-                return Ok(content);
+                std::mem::drop(self.bucket.put(&path, content.clone().into()));
+                Ok(content)
             } else {
                 bail!("Failed to fetch debuginfo: {}", response.status());
             }
         } else {
-            return Ok(res.to_vec());
+            Ok(res.to_vec())
         }
     }
 }

--- a/src/debuginfo_store/fetcher.rs
+++ b/src/debuginfo_store/fetcher.rs
@@ -1,58 +1,51 @@
 use anyhow::bail;
+use object_store::ObjectStore;
 
 use super::DebugInfod;
 use crate::debuginfopb::{debuginfo::Source, Debuginfo};
-use std::{
-    collections::HashMap,
-    sync::{Arc, Mutex},
-};
+use std::sync::{Arc, Mutex};
 
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct DebuginfoFetcher {
-    bucket: Arc<Mutex<HashMap<String, Vec<u8>>>>,
-    debuginfod: Arc<Mutex<DebugInfod>>,
+    bucket: Arc<dyn ObjectStore>,
+    debuginfod: DebugInfod,
 }
 
 impl DebuginfoFetcher {
-    pub fn new(
-        bucket: Arc<Mutex<HashMap<String, Vec<u8>>>>,
-        debuginfod: Arc<Mutex<DebugInfod>>,
-    ) -> Self {
+    pub fn new(bucket: Arc<dyn ObjectStore>, debuginfod: DebugInfod) -> Self {
         Self { bucket, debuginfod }
     }
 
-    pub fn fetch_raw_elf(&self, dbginfo: &Debuginfo) -> anyhow::Result<Vec<u8>> {
+    pub async fn fetch_raw_elf(&self, dbginfo: &Debuginfo) -> anyhow::Result<Vec<u8>> {
         let source = dbginfo.source();
         match source {
-            Source::Debuginfod => self.fetch_debuginfod(dbginfo),
-            Source::Upload => self.fetch_bucket(dbginfo),
+            Source::Debuginfod => self.fetch_debuginfod(dbginfo).await,
+            Source::Upload => self.fetch_bucket(dbginfo).await,
             _ => {
                 bail!("Unknown source in Debuginfo");
             }
         }
     }
 
-    fn fetch_debuginfod(&self, dbginfo: &Debuginfo) -> anyhow::Result<Vec<u8>> {
-        let mut debuginfod = match self.debuginfod.lock() {
-            Ok(debuginfod) => debuginfod,
-            Err(_) => bail!("DebugInfoD_Error:Failed to lock DebugInfod"),
-        };
-
-        let servers = debuginfod.upstream_servers.clone();
-        let rc = debuginfod.get(&servers[0], dbginfo.build_id.as_str())?;
+    async fn fetch_debuginfod(&self, dbginfo: &Debuginfo) -> anyhow::Result<Vec<u8>> {
+        let rc = self
+            .debuginfod
+            .get(
+                &self.debuginfod.upstream_servers[0],
+                dbginfo.build_id.as_str(),
+            )
+            .await?;
         Ok(rc.to_vec())
     }
 
-    fn fetch_bucket(&self, dbginfo: &Debuginfo) -> anyhow::Result<Vec<u8>> {
-        let bucket = match self.bucket.lock() {
-            Ok(bucket) => bucket,
-            Err(_) => bail!("DebugInfoD_Error:Failed to lock DebugInfo storage bucket"),
-        };
-        let path = &dbginfo.upload.as_ref().unwrap().id;
+    async fn fetch_bucket(&self, dbginfo: &Debuginfo) -> anyhow::Result<Vec<u8>> {
+        let path: &str = &dbginfo.upload.as_ref().unwrap().id;
 
-        if let Some(rc) = bucket.get(path) {
-            return Ok(rc.clone());
-        }
-        bail!("No data found in bucket");
+        let rc = self
+            .bucket
+            .get(&object_store::path::Path::from(path))
+            .await?;
+
+        Ok(rc.bytes().await?.to_vec())
     }
 }

--- a/src/debuginfo_store/fetcher.rs
+++ b/src/debuginfo_store/fetcher.rs
@@ -1,9 +1,8 @@
-use anyhow::bail;
-use object_store::ObjectStore;
-
 use super::DebugInfod;
 use crate::debuginfopb::{debuginfo::Source, Debuginfo};
-use std::sync::{Arc, Mutex};
+use anyhow::bail;
+use object_store::ObjectStore;
+use std::sync::Arc;
 
 #[derive(Debug)]
 pub struct DebuginfoFetcher {

--- a/src/debuginfo_store/mod.rs
+++ b/src/debuginfo_store/mod.rs
@@ -67,6 +67,7 @@ impl DebuginfoService for DebuginfoStore {
         let request = match stream.message().await {
             Ok(Some(msg)) => msg,
             Ok(None) => return Err(Status::invalid_argument("Empty request")),
+
             Err(e) => {
                 return Err(Status::internal(format!(
                     "Failed to receive message: {}",
@@ -409,7 +410,7 @@ impl DebuginfoStore {
             reason: if !self.is_valid_elf(debuginfo) {
                 DebugInfoUploadReason::DebugInfodSource.to_string()
             } else {
-                DebugInfoUploadReason::DebugInfoInvalid.to_string()
+                DebugInfoUploadReason::DebugInfodInvalid.to_string()
             },
         }))
     }

--- a/src/debuginfo_store/mod.rs
+++ b/src/debuginfo_store/mod.rs
@@ -15,6 +15,7 @@ use chrono::{DateTime, Duration, TimeZone, Utc};
 pub use debuginfod::DebugInfod;
 pub use fetcher::DebuginfoFetcher;
 pub use metadata::MetadataStore;
+use object_store::ObjectStore;
 use std::collections::HashMap;
 use std::result::Result;
 use std::sync::{Arc, Mutex};
@@ -62,11 +63,11 @@ impl TryFrom<upload_request::Data> for UploadRequestInfo {
 }
 
 pub struct DebuginfoStore {
-    pub(crate) metadata: Arc<Mutex<MetadataStore>>,
-    pub(crate) debuginfod: Arc<Mutex<DebugInfod>>,
+    pub(crate) metadata: MetadataStore,
+    pub(crate) debuginfod: DebugInfod,
     pub(crate) max_upload_duration: Duration,
     pub(crate) max_upload_size: i64,
-    pub(crate) bucket: Arc<Mutex<HashMap<String, Vec<u8>>>>,
+    pub(crate) bucket: Arc<dyn ObjectStore>,
 }
 
 #[async_trait]
@@ -96,21 +97,15 @@ impl DebuginfoService for DebuginfoStore {
         let upload_info = UploadRequestInfo::try_from(data)?;
         let _ = self.validate_buildid(&upload_info.buildid)?;
 
-        let dbginfo = {
-            let metadata = self
-                .metadata
-                .lock()
-                .map_err(|_| Status::internal("Failed to lock metadata"))?;
-
-            metadata
-                .fetch(&upload_info.buildid, &upload_info.debuginfo_type)
-                .ok_or_else(|| {
-                    Status::failed_precondition(
+        let dbginfo = self
+            .metadata
+            .fetch(&upload_info.buildid, &upload_info.debuginfo_type)
+            .ok_or_else(|| {
+                Status::failed_precondition(
                 "metadata not found, this indicates that the upload was not previously initiated"
             )
-                })?
-                .clone()
-        };
+            })?
+            .clone();
 
         let upload = dbginfo.upload.ok_or_else(|| {
             Status::invalid_argument(
@@ -141,13 +136,22 @@ impl DebuginfoService for DebuginfoStore {
 
         let size = chunks.len() as u64;
 
+        match self
+            .bucket
+            .put(
+                &object_store::path::Path::from(upload_info.upload_id),
+                chunks.into(),
+            )
+            .await
         {
-            let mut bucket = self
-                .bucket
-                .lock()
-                .map_err(|_| Status::internal("Failed to lock bucket"))?;
-            bucket.insert(upload_info.upload_id, chunks);
-        }
+            Ok(_) => {}
+            Err(e) => {
+                return Err(Status::internal(format!(
+                    "Failed to store debuginfo: {}",
+                    e
+                )))
+            }
+        };
 
         Ok(Response::new(UploadResponse {
             build_id: upload_info.buildid,
@@ -166,19 +170,11 @@ impl DebuginfoService for DebuginfoStore {
         let request = request.into_inner();
         let _ = self.validate_buildid(&request.build_id)?;
 
-        let debuginfo = {
-            let metadata = self
-                .metadata
-                .lock()
-                .map_err(|_| Status::internal("Failed to lock metadata"))?;
-            metadata
-                .fetch(&request.build_id, &request.r#type())
-                .cloned()
-        };
+        let debuginfo = self.metadata.fetch(&request.build_id, &request.r#type());
 
         match debuginfo {
             Some(info) => self.handle_existing_debuginfo(&request, &info),
-            None => self.handle_new_build_id(&request),
+            None => Box::pin(self.handle_new_build_id(&request)).await,
         }
     }
 
@@ -232,11 +228,8 @@ impl DebuginfoService for DebuginfoStore {
         // let upload_expired = upload_started + self.max_upload_duration;
 
         {
-            let mut metadata = self
+            let _ = self
                 .metadata
-                .lock()
-                .map_err(|_| Status::internal("Failed to lock metadata"))?;
-            let _ = metadata
                 .mark_as_uploading(
                     &request.build_id,
                     &upload_id,
@@ -270,22 +263,17 @@ impl DebuginfoService for DebuginfoStore {
 
         let request = request.into_inner();
         let _ = self.validate_buildid(&request.build_id)?;
-        {
-            let mut metadata = self
-                .metadata
-                .lock()
-                .map_err(|_| Status::internal("Failed to lock metadata"))?;
-            let _ = metadata
-                .mark_as_uploaded(
-                    &request.build_id,
-                    &request.upload_id,
-                    &request.r#type(),
-                    self.time_now(),
-                )
-                .map_err(|e| {
-                    Status::internal(format!("Failed to mark metadata as uploaded. details: {e}"))
-                })?;
-        }
+        let _ = self
+            .metadata
+            .mark_as_uploaded(
+                &request.build_id,
+                &request.upload_id,
+                &request.r#type(),
+                self.time_now(),
+            )
+            .map_err(|e| {
+                Status::internal(format!("Failed to mark metadata as uploaded. details: {e}"))
+            })?;
         Ok(Response::new(MarkUploadFinishedResponse::default()))
     }
 }
@@ -442,7 +430,7 @@ impl DebuginfoStore {
         }))
     }
 
-    fn handle_new_build_id(
+    async fn handle_new_build_id(
         &self,
         request: &ShouldInitiateUploadRequest,
     ) -> Result<Response<ShouldInitiateUploadResponse>, Status> {
@@ -456,27 +444,14 @@ impl DebuginfoStore {
             }));
         }
 
-        let exists = {
-            let mut debuginfod = self
-                .debuginfod
-                .lock()
-                .map_err(|_| Status::internal("Failed to lock debuginfod"))?;
-            debuginfod.exists(&request.build_id)
-        };
+        // Check existence outside of the lock
+        let build_id = request.build_id.clone();
+        let exists = self.debuginfod.exists(&build_id).await;
 
         if !exists.is_empty() {
-            {
-                let mut metadata = self
-                    .metadata
-                    .lock()
-                    .map_err(|_| Status::internal("Failed to lock metadata"))?;
-                let _ = metadata.mark_as_debuginfod_source(
-                    exists,
-                    &request.build_id,
-                    &request.r#type(),
-                );
-            }
-
+            let _ = self
+                .metadata
+                .mark_as_debuginfod_source(exists, &build_id, &request.r#type());
             Ok(Response::new(ShouldInitiateUploadResponse {
                 should_initiate_upload: false,
                 reason: REASON_DEBUGINFO_IN_DEBUGINFOD.into(),

--- a/src/debuginfo_store/mod.rs
+++ b/src/debuginfo_store/mod.rs
@@ -242,7 +242,7 @@ impl DebuginfoService for DebuginfoStore {
     async fn mark_upload_finished(
         &self,
         request: Request<MarkUploadFinishedRequest>,
-    ) -> Result<Response<MarkUploadFinishedResponse>, Status> {
+    ) -> anyhow::Result<Response<MarkUploadFinishedResponse>, Status> {
         // log::info!("MarkUploadFinished request received");
 
         let request = request.into_inner();
@@ -263,7 +263,7 @@ impl DebuginfoService for DebuginfoStore {
 }
 
 impl DebuginfoStore {
-    fn validate_buildid(&self, id: &str) -> Result<(), Status> {
+    fn validate_buildid(&self, id: &str) -> anyhow::Result<(), Status> {
         if id.len() <= 2 {
             return Err(Status::invalid_argument("unexpectedly short input"));
         }
@@ -293,7 +293,7 @@ impl DebuginfoStore {
         &self,
         request: &ShouldInitiateUploadRequest,
         debuginfo: &Debuginfo,
-    ) -> Result<Response<ShouldInitiateUploadResponse>, Status> {
+    ) -> anyhow::Result<Response<ShouldInitiateUploadResponse>, Status> {
         match Source::try_from(debuginfo.source) {
             Ok(Source::Debuginfod) => self.handle_debuginfod_source(debuginfo),
             Ok(Source::Upload) => self.handle_upload_source(request, debuginfo),
@@ -305,7 +305,7 @@ impl DebuginfoStore {
         &self,
         request: &ShouldInitiateUploadRequest,
         debuginfo: &Debuginfo,
-    ) -> Result<Response<ShouldInitiateUploadResponse>, Status> {
+    ) -> anyhow::Result<Response<ShouldInitiateUploadResponse>, Status> {
         let upload = debuginfo
             .upload
             .as_ref()
@@ -323,7 +323,7 @@ impl DebuginfoStore {
     fn handle_uploading_state(
         &self,
         upload: &DebuginfoUpload,
-    ) -> Result<Response<ShouldInitiateUploadResponse>, Status> {
+    ) -> anyhow::Result<Response<ShouldInitiateUploadResponse>, Status> {
         if self.is_upload_stale(upload) {
             Ok(Response::new(ShouldInitiateUploadResponse {
                 should_initiate_upload: true,
@@ -341,7 +341,7 @@ impl DebuginfoStore {
         &self,
         request: &ShouldInitiateUploadRequest,
         debuginfo: &Debuginfo,
-    ) -> Result<Response<ShouldInitiateUploadResponse>, Status> {
+    ) -> anyhow::Result<Response<ShouldInitiateUploadResponse>, Status> {
         if !self.is_valid_elf(debuginfo) {
             return self.handle_invalid_elf(request);
         }
@@ -366,7 +366,7 @@ impl DebuginfoStore {
     fn handle_invalid_elf(
         &self,
         request: &ShouldInitiateUploadRequest,
-    ) -> Result<Response<ShouldInitiateUploadResponse>, Status> {
+    ) -> anyhow::Result<Response<ShouldInitiateUploadResponse>, Status> {
         Ok(Response::new(ShouldInitiateUploadResponse {
             should_initiate_upload: request.force,
             reason: if request.force {
@@ -381,7 +381,7 @@ impl DebuginfoStore {
         &self,
         request: &ShouldInitiateUploadRequest,
         debuginfo: &Debuginfo,
-    ) -> Result<Response<ShouldInitiateUploadResponse>, Status> {
+    ) -> anyhow::Result<Response<ShouldInitiateUploadResponse>, Status> {
         match &debuginfo.upload {
             Some(upload) if upload.hash.eq(&request.hash) => {
                 Ok(Response::new(ShouldInitiateUploadResponse {
@@ -403,7 +403,7 @@ impl DebuginfoStore {
     fn handle_debuginfod_source(
         &self,
         debuginfo: &Debuginfo,
-    ) -> Result<Response<ShouldInitiateUploadResponse>, Status> {
+    ) -> anyhow::Result<Response<ShouldInitiateUploadResponse>, Status> {
         Ok(Response::new(ShouldInitiateUploadResponse {
             should_initiate_upload: true,
             reason: if !self.is_valid_elf(debuginfo) {
@@ -417,7 +417,7 @@ impl DebuginfoStore {
     async fn handle_new_build_id(
         &self,
         request: &ShouldInitiateUploadRequest,
-    ) -> Result<Response<ShouldInitiateUploadResponse>, Status> {
+    ) -> anyhow::Result<Response<ShouldInitiateUploadResponse>, Status> {
         if !matches!(
             request.build_id_type(),
             BuildIdType::Gnu | BuildIdType::UnknownUnspecified

--- a/src/debuginfo_store/reasons.rs
+++ b/src/debuginfo_store/reasons.rs
@@ -1,0 +1,69 @@
+#[derive(Debug, Clone, PartialEq)]
+pub enum DebugInfoUploadReason {
+    /// Debuginfo exists in debuginfod, therefore no upload is necessary.
+    DebugInfoInDebugInfod,
+
+    /// First time we see this Build ID, and it does not exist in debuginfod, therefore please upload!
+    FirstTimeSeen,
+
+    /// A previous upload was started but not finished and is now stale, so it can be retried.
+    UploadStale,
+
+    /// A previous upload is still in-progress and not stale yet (only stale uploads can be retried).
+    UploadInProgress,
+
+    /// Debuginfo already exists and is not marked as invalid, therefore no new upload is needed.
+    DebugInfoAlreadyExists,
+
+    /// Debuginfo already exists and is not marked as invalid, therefore wouldn't have accepted a new upload, 
+    /// but accepting it because it's requested to be forced.
+    DebugInfoAlreadyExistsButForced,
+
+    /// Debuginfo already exists but is marked as invalid, therefore a new upload is needed. 
+    /// Hash the debuginfo and initiate the upload.
+    DebugInfoInvalid,
+
+    /// Debuginfo already exists and is marked as invalid, but the proposed hash is the same as the 
+    /// one already available, therefore the upload is not accepted as it would result in the same invalid debuginfos.
+    DebugInfoEqual,
+
+    /// Debuginfo already exists but is marked as invalid, therefore a new upload will be accepted.
+    DebugInfoNotEqual,
+
+    /// Debuginfo is available from debuginfod already and not marked as invalid, therefore no new upload is needed.
+    DebugInfodSource,
+
+    /// Debuginfo is available from debuginfod already but is marked as invalid, therefore a new upload is needed.
+    DebugInfodInvalid,
+}
+
+impl DebugInfoUploadReason {
+    /// Convert the enum variant to a descriptive string
+    pub fn to_string(&self) -> String{
+        let r = match self {
+            Self::DebugInfoInDebugInfod => 
+                "Debuginfo exists in debuginfod, therefore no upload is necessary.",
+            Self::FirstTimeSeen => 
+                "First time we see this Build ID, and it does not exist in debuginfod, therefore please upload!",
+            Self::UploadStale => 
+                "A previous upload was started but not finished and is now stale, so it can be retried.",
+            Self::UploadInProgress => 
+                "A previous upload is still in-progress and not stale yet (only stale uploads can be retried).",
+            Self::DebugInfoAlreadyExists => 
+                "Debuginfo already exists and is not marked as invalid, therefore no new upload is needed.",
+            Self::DebugInfoAlreadyExistsButForced => 
+                "Debuginfo already exists and is not marked as invalid, therefore wouldn't have accepted a new upload, but accepting it because it's requested to be forced.",
+            Self::DebugInfoInvalid => 
+                "Debuginfo already exists but is marked as invalid, therefore a new upload is needed. Hash the debuginfo and initiate the upload.",
+            Self::DebugInfoEqual => 
+                "Debuginfo already exists and is marked as invalid, but the proposed hash is the same as the one already available, therefore the upload is not accepted as it would result in the same invalid debuginfos.",
+            Self::DebugInfoNotEqual => 
+                "Debuginfo already exists but is marked as invalid, therefore a new upload will be accepted.",
+            Self::DebugInfodSource => 
+                "Debuginfo is available from debuginfod already and not marked as invalid, therefore no new upload is needed.",
+            Self::DebugInfodInvalid => 
+                "Debuginfo is available from debuginfod already but is marked as invalid, therefore a new upload is needed.",
+        };
+        r.to_string()
+    }
+}

--- a/src/debuginfo_store/reasons.rs
+++ b/src/debuginfo_store/reasons.rs
@@ -37,33 +37,33 @@ pub enum DebugInfoUploadReason {
     DebugInfodInvalid,
 }
 
-impl DebugInfoUploadReason {
-    /// Convert the enum variant to a descriptive string
-    pub fn to_string(&self) -> String{
+impl std::fmt::Display for DebugInfoUploadReason {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let r = match self {
             Self::DebugInfoInDebugInfod => 
-                "Debuginfo exists in debuginfod, therefore no upload is necessary.",
+            "Debuginfo exists in debuginfod, therefore no upload is necessary.",
             Self::FirstTimeSeen => 
-                "First time we see this Build ID, and it does not exist in debuginfod, therefore please upload!",
+            "First time we see this Build ID, and it does not exist in debuginfod, therefore please upload!",
             Self::UploadStale => 
-                "A previous upload was started but not finished and is now stale, so it can be retried.",
+            "A previous upload was started but not finished and is now stale, so it can be retried.",
             Self::UploadInProgress => 
-                "A previous upload is still in-progress and not stale yet (only stale uploads can be retried).",
+            "A previous upload is still in-progress and not stale yet (only stale uploads can be retried).",
             Self::DebugInfoAlreadyExists => 
-                "Debuginfo already exists and is not marked as invalid, therefore no new upload is needed.",
+            "Debuginfo already exists and is not marked as invalid, therefore no new upload is needed.",
             Self::DebugInfoAlreadyExistsButForced => 
-                "Debuginfo already exists and is not marked as invalid, therefore wouldn't have accepted a new upload, but accepting it because it's requested to be forced.",
+            "Debuginfo already exists and is not marked as invalid, therefore wouldn't have accepted a new upload, but accepting it because it's requested to be forced.",
             Self::DebugInfoInvalid => 
-                "Debuginfo already exists but is marked as invalid, therefore a new upload is needed. Hash the debuginfo and initiate the upload.",
+            "Debuginfo already exists but is marked as invalid, therefore a new upload is needed. Hash the debuginfo and initiate the upload.",
             Self::DebugInfoEqual => 
-                "Debuginfo already exists and is marked as invalid, but the proposed hash is the same as the one already available, therefore the upload is not accepted as it would result in the same invalid debuginfos.",
+            "Debuginfo already exists and is marked as invalid, but the proposed hash is the same as the one already available, therefore the upload is not accepted as it would result in the same invalid debuginfos.",
             Self::DebugInfoNotEqual => 
-                "Debuginfo already exists but is marked as invalid, therefore a new upload will be accepted.",
+            "Debuginfo already exists but is marked as invalid, therefore a new upload will be accepted.",
             Self::DebugInfodSource => 
-                "Debuginfo is available from debuginfod already and not marked as invalid, therefore no new upload is needed.",
+            "Debuginfo is available from debuginfod already and not marked as invalid, therefore no new upload is needed.",
             Self::DebugInfodInvalid => 
-                "Debuginfo is available from debuginfod already but is marked as invalid, therefore a new upload is needed.",
+            "Debuginfo is available from debuginfod already but is marked as invalid, therefore a new upload is needed.",
         };
-        r.to_string()
+        write!(f, "{}", r)
     }
+
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ use std::{
 use chrono::TimeDelta;
 use debuginfo_store::DebuginfoFetcher;
 use debuginfopb::debuginfo_service_server::DebuginfoServiceServer;
+use object_store::ObjectStore;
 use profilestorepb::{
     agents_service_server::AgentsServiceServer,
     profile_store_service_server::ProfileStoreServiceServer,
@@ -17,6 +18,7 @@ mod debuginfo_store;
 mod normalizer;
 mod profile;
 mod profile_store;
+mod storage;
 mod symbolizer;
 mod symbols;
 
@@ -40,12 +42,12 @@ pub(crate) mod debuginfopb {
 async fn main() -> anyhow::Result<()> {
     colog::init();
 
-    let metadata_store = Arc::new(Mutex::new(debuginfo_store::MetadataStore::new()));
-    let debuginfod = Arc::new(Mutex::new(debuginfo_store::DebugInfod::default()));
-    let bucket: Arc<Mutex<HashMap<String, Vec<u8>>>> = Arc::new(Mutex::from(HashMap::new()));
+    let metadata_store = debuginfo_store::MetadataStore::new();
+    let debuginfod = debuginfo_store::DebugInfod::default();
+    let bucket: Arc<dyn ObjectStore> = Arc::new(storage::new_memory_bucket());
     let symbolizer = Arc::new(symbolizer::Symbolizer::new(
-        Arc::clone(&metadata_store),
-        DebuginfoFetcher::new(Arc::clone(&bucket), Arc::clone(&debuginfod)),
+        debuginfo_store::MetadataStore::with_store(metadata_store.store.clone()),
+        DebuginfoFetcher::new(Arc::clone(&bucket), debuginfod.clone()),
     ));
 
     log::info!("Starting Server");
@@ -60,8 +62,8 @@ async fn main() -> anyhow::Result<()> {
 
     log::info!("Attaching DebugInfo to the server");
     let debug_store_impl = debuginfo_store::DebuginfoStore {
-        metadata: Arc::clone(&metadata_store),
-        debuginfod: Arc::clone(&debuginfod),
+        metadata: metadata_store,
+        debuginfod: debuginfod,
         max_upload_duration: TimeDelta::new(60 * 15, 0).unwrap(),
         max_upload_size: 1000000000,
         bucket: Arc::clone(&bucket),

--- a/src/normalizer/mod.rs
+++ b/src/normalizer/mod.rs
@@ -7,4 +7,4 @@ mod write_raw;
 use profile::NormalizedProfile;
 pub use sample::NormalizedSample;
 pub use series::Series;
-pub use utils::write_raw_request_to_arrow_record;
+pub use utils::write_raw_request_to_arrow_chunk;

--- a/src/normalizer/profile.rs
+++ b/src/normalizer/profile.rs
@@ -1,7 +1,8 @@
 use super::NormalizedSample;
 use crate::profile::Meta;
+use serde::{Deserialize, Serialize};
 
-#[derive(Debug)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct NormalizedProfile {
     pub(crate) samples: Vec<NormalizedSample>,
     pub(crate) meta: Meta,

--- a/src/normalizer/sample.rs
+++ b/src/normalizer/sample.rs
@@ -1,6 +1,8 @@
 use std::collections::HashMap;
 
-#[derive(Debug)]
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Debug)]
 pub struct NormalizedSample {
     pub(crate) locations: Vec<Vec<u8>>,
     pub(crate) value: i64,

--- a/src/normalizer/series.rs
+++ b/src/normalizer/series.rs
@@ -1,7 +1,8 @@
 use super::NormalizedProfile;
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
-#[derive(Debug)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct Series {
     pub(crate) labels: HashMap<String, String>,
     pub(crate) samples: Vec<Vec<NormalizedProfile>>,

--- a/src/normalizer/utils.rs
+++ b/src/normalizer/utils.rs
@@ -328,24 +328,6 @@ pub async fn write_raw_request_to_arrow_record(
 ) -> anyhow::Result<RecordBatch> {
     let normalized_request = NormalizedWriteRawRequest::try_from(request)?;
 
-    for series in normalized_request.series.iter() {
-        for sample in series.samples.iter() {
-            for np in sample.iter() {
-                for ns in np.samples.iter() {
-                    let x = profile::symbolize_locations(
-                        ns.locations.as_slice(),
-                        Arc::clone(&symbolizer),
-                    )
-                    .await?;
-                    log::warn!("{:#?}", x.first().take());
-                    return Ok(RecordBatch::new_empty(Arc::new(schema::create_schema(
-                        &normalized_request.all_label_names,
-                    ))));
-                }
-            }
-        }
-    }
-
     Ok(RecordBatch::new_empty(Arc::new(schema::create_schema(
         &normalized_request.all_label_names,
     ))))

--- a/src/normalizer/utils.rs
+++ b/src/normalizer/utils.rs
@@ -328,7 +328,7 @@ fn serialize_pprof_stacktrace(
     Ok(stacktrace)
 }
 
-pub fn write_raw_request_to_arrow_record(
+pub async fn write_raw_request_to_arrow_record(
     request: &WriteRawRequest,
     symbolizer: Arc<Symbolizer>,
 ) -> anyhow::Result<RecordBatch> {
@@ -341,7 +341,8 @@ pub fn write_raw_request_to_arrow_record(
                     let x = profile::symbolize_locations(
                         ns.locations.as_slice(),
                         Arc::clone(&symbolizer),
-                    )?;
+                    )
+                    .await?;
                     log::warn!("{:#?}", x.first().take());
                     return Ok(RecordBatch::new_empty(Arc::new(schema::create_schema(
                         &normalized_request.all_label_names,

--- a/src/normalizer/utils.rs
+++ b/src/normalizer/utils.rs
@@ -6,15 +6,9 @@ use crate::profile::{self, schema, Meta, PprofLocations, ValueType};
 use crate::profilestorepb::{ExecutableInfo, WriteRawRequest};
 use crate::symbolizer::Symbolizer;
 use anyhow::bail;
-use arrow::array::{
-    ArrayRef, BinaryDictionaryBuilder, GenericByteDictionaryBuilder, Int64Builder, ListBuilder,
-};
-use arrow::datatypes::{GenericBinaryType, Int32Type};
 use arrow::record_batch::RecordBatch;
 use std::collections::{HashMap, HashSet};
-use std::result::Result;
 use std::sync::Arc;
-use tonic::Status;
 
 const NANOS_PER_MILLI: i64 = 1_000_000;
 

--- a/src/normalizer/write_raw.rs
+++ b/src/normalizer/write_raw.rs
@@ -51,7 +51,7 @@ impl TryFrom<&WriteRawRequest> for NormalizedWriteRawRequest {
                 let mut decompressed = Vec::new();
 
                 let mut decoder = GzDecoder::new(sample.raw_profile.as_slice());
-                if decoder.header().is_none() {
+                if decoder.header().is_some() {
                     if let Err(e) = decoder.read_to_end(&mut decompressed) {
                         bail!("Failed to decompress gzip: {}", e);
                     }

--- a/src/normalizer/write_raw.rs
+++ b/src/normalizer/write_raw.rs
@@ -4,10 +4,11 @@ use crate::profilestorepb::WriteRawRequest;
 use anyhow::bail;
 use flate2::read::GzDecoder;
 use prost::Message;
+use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use std::io::Read;
 
-#[derive(Debug)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct NormalizedWriteRawRequest {
     pub(crate) series: Vec<Series>,
     pub(crate) all_label_names: Vec<String>,

--- a/src/profile/executableinfo.rs
+++ b/src/profile/executableinfo.rs
@@ -179,7 +179,7 @@ pub fn find_text_prog_hdr(e: &File<'_>) -> i16 {
 
                 if p_flags & PF_X != 0
                     && section_addr >= segment_addr
-                    && section_addr < segment_addr + segment.size()
+                    && section_addr < segment_addr + segment_size
                 {
                     return indx as i16;
                 }

--- a/src/profile/mod.rs
+++ b/src/profile/mod.rs
@@ -4,11 +4,8 @@ pub mod schema;
 mod utils;
 
 use crate::metapb::{Function, Mapping};
-use arrow::record_batch::RecordBatch;
 pub use encode::PprofLocations;
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
-pub use utils::symbolize_locations;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LocationLine {
@@ -35,61 +32,13 @@ pub struct Location {
     pub lines: Vec<LocationLine>,
 }
 
-#[derive(Debug, Clone)]
-pub struct Label {
-    pub name: String,
-    pub value: String,
-}
-
-#[derive(Debug, Clone)]
-pub struct NumLabel {
-    pub name: String,
-    pub value: i64,
-}
-
-#[derive(Debug, Clone)]
-pub struct SymbolizedSample {
-    pub locations: Vec<Location>,
-    pub value: i64,
-    pub diff_value: i64,
-    pub label: HashMap<String, String>,
-    pub num_label: HashMap<String, i64>,
-}
-
-#[derive(Debug, Clone)]
-pub struct NormalizedSample {
-    pub stacktrace_id: String,
-    pub value: i64,
-    pub diff_value: i64,
-    pub label: HashMap<String, String>,
-    pub num_label: HashMap<String, i64>,
-}
-
-#[derive(Debug, Clone)]
-pub struct Profile {
-    pub samples: Vec<RecordBatch>,
-    pub meta: Meta,
-}
-
-#[derive(Debug, Clone)]
-pub struct OldProfile {
-    pub meta: Meta,
-    pub samples: Vec<SymbolizedSample>,
-}
-
-#[derive(Debug, Clone)]
-pub struct NormalizedProfile {
-    pub samples: Vec<NormalizedSample>,
-    pub meta: Meta,
-}
-
-#[derive(Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct ValueType {
     pub type_: String,
     pub unit: String,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Meta {
     pub name: String,
     pub period_type: ValueType,

--- a/src/profile/schema.rs
+++ b/src/profile/schema.rs
@@ -1,6 +1,4 @@
-use std::sync::Arc;
-
-use arrow::datatypes::{DataType, Field, Schema};
+use arrow2::datatypes::{DataType, Field, IntegerType, Schema};
 
 const COLUMN_DURATION: &str = "duration";
 const COLUMN_LABELS: &str = "labels";
@@ -20,38 +18,38 @@ pub fn create_schema(labels: &[String]) -> Schema {
         Field::new(COLUMN_DURATION, DataType::Int64, false),
         Field::new(
             COLUMN_NAME,
-            DataType::Dictionary(Box::new(DataType::Int32), Box::new(DataType::Binary)),
+            DataType::Dictionary(IntegerType::Int32, Box::new(DataType::Utf8), false),
             false,
         ),
         Field::new(COLUMN_PERIOD, DataType::Int64, false),
         Field::new(
             COLUMN_PERIOD_TYPE,
-            DataType::Dictionary(Box::new(DataType::Int32), Box::new(DataType::Binary)),
+            DataType::Dictionary(IntegerType::Int32, Box::new(DataType::Utf8), false),
             false,
         ),
         Field::new(
             COLUMN_PERIOD_UNIT,
-            DataType::Dictionary(Box::new(DataType::Int32), Box::new(DataType::Binary)),
+            DataType::Dictionary(IntegerType::Int32, Box::new(DataType::Utf8), false),
             false,
         ),
         Field::new(
             COLUMN_SAMPLE_TYPE,
-            DataType::Dictionary(Box::new(DataType::Int32), Box::new(DataType::Binary)),
+            DataType::Dictionary(IntegerType::Int32, Box::new(DataType::Utf8), false),
             false,
         ),
         Field::new(
             COLUMN_SAMPLE_UNIT,
-            DataType::Dictionary(Box::new(DataType::Int32), Box::new(DataType::Binary)),
+            DataType::Dictionary(IntegerType::Int32, Box::new(DataType::Utf8), false),
             false,
         ),
         Field::new(
             COLUMN_STACKTRACE,
-            DataType::List(Arc::new(Field::new(
+            DataType::List(Box::new(Field::new(
                 COLUMN_STACKTRACE_ITEM,
-                DataType::Dictionary(Box::new(DataType::Int32), Box::new(DataType::Binary)),
-                true,
+                DataType::Binary,
+                false,
             ))),
-            true,
+            false,
         ),
         Field::new(COLUMN_TIMESTAMP, DataType::Int64, false),
         Field::new(COLUMN_VALUE, DataType::Int64, false),
@@ -60,10 +58,10 @@ pub fn create_schema(labels: &[String]) -> Schema {
     for label in labels {
         fields.push(Field::new(
             format!("{}.{}", COLUMN_LABELS, label),
-            DataType::Dictionary(Box::new(DataType::Int32), Box::new(DataType::Binary)),
+            DataType::Dictionary(IntegerType::Int32, Box::new(DataType::Utf8), false),
             true,
         ));
     }
 
-    Schema::new(fields)
+    Schema::from(fields)
 }

--- a/src/profile/utils.rs
+++ b/src/profile/utils.rs
@@ -98,7 +98,7 @@ pub struct MappingLocations {
     locations: HashMap<u64, super::Location>,
 }
 
-pub fn symbolize_locations(
+pub async fn symbolize_locations(
     locations: &[Vec<u8>],
     symbolizer: Arc<crate::symbolizer::Symbolizer>,
 ) -> anyhow::Result<Vec<super::Location>> {
@@ -167,7 +167,7 @@ pub fn symbolize_locations(
         }
 
         // Mutate the request in-place
-        symbolizer.symbolize(&mut sym_req)?;
+        symbolizer.symbolize(&mut sym_req).await?;
 
         // Extract symbolized locations from the mutated request
         for mapping in sym_req.mappings {

--- a/src/profile_store.rs
+++ b/src/profile_store.rs
@@ -64,12 +64,7 @@ impl ProfileStore {
     }
 
     pub async fn write_series(&self, request: &WriteRawRequest) -> anyhow::Result<()> {
-        let record = match normalizer::write_raw_request_to_arrow_record(
-            request,
-            Arc::clone(&self.symbolizer),
-        )
-        .await
-        {
+        let (chunk, schema) = match normalizer::write_raw_request_to_arrow_chunk(request).await {
             Ok(record) => record,
             Err(e) => {
                 bail!(
@@ -79,7 +74,7 @@ impl ProfileStore {
             }
         };
 
-        if record.num_rows() == 0 {
+        if chunk.is_empty() {
             return Ok(());
         }
 

--- a/src/profile_store.rs
+++ b/src/profile_store.rs
@@ -19,7 +19,7 @@ impl ProfileStoreService for ProfileStore {
         &self,
         request: Request<WriteRawRequest>,
     ) -> anyhow::Result<Response<WriteRawResponse>, Status> {
-        let _ = match self.write_series(&request.into_inner()) {
+        let _ = match self.write_series(&request.into_inner()).await {
             Ok(_) => (),
             Err(e) => return Err(Status::internal(e.to_string())),
         };
@@ -63,11 +63,13 @@ impl ProfileStore {
         }
     }
 
-    pub fn write_series(&self, request: &WriteRawRequest) -> anyhow::Result<()> {
+    pub async fn write_series(&self, request: &WriteRawRequest) -> anyhow::Result<()> {
         let record = match normalizer::write_raw_request_to_arrow_record(
             request,
             Arc::clone(&self.symbolizer),
-        ) {
+        )
+        .await
+        {
             Ok(record) => record,
             Err(e) => {
                 bail!(

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -1,0 +1,5 @@
+use object_store::{memory::InMemory, ObjectStore};
+
+pub fn new_memory_bucket() -> impl ObjectStore {
+    InMemory::new()
+}

--- a/src/symbolizer/mod.rs
+++ b/src/symbolizer/mod.rs
@@ -16,8 +16,6 @@ use liner::Liner;
 use normalize::NormalizedAddress;
 use std::io::Write;
 use std::path::PathBuf;
-use std::sync::MutexGuard;
-use std::sync::{Arc, Mutex};
 use tonic::Status;
 
 #[derive(Debug)]

--- a/src/symbolizer/mod.rs
+++ b/src/symbolizer/mod.rs
@@ -24,7 +24,7 @@ use tonic::Status;
 pub struct Symbolizer {
     pub(crate) demangler: Demangler,
     cache: SymbolizerCache,
-    metadata: Arc<Mutex<MetadataStore>>,
+    metadata: MetadataStore,
     fetcher: DebuginfoFetcher,
     temp_dir: PathBuf,
 }
@@ -49,7 +49,7 @@ pub struct ElfDebugInfo<'data> {
 }
 
 impl Symbolizer {
-    pub fn new(metadata: Arc<Mutex<MetadataStore>>, fetcher: DebuginfoFetcher) -> Self {
+    pub fn new(metadata: MetadataStore, fetcher: DebuginfoFetcher) -> Self {
         Self {
             demangler: Demangler::new(false),
             cache: SymbolizerCache::default(),
@@ -59,14 +59,13 @@ impl Symbolizer {
         }
     }
 
-    pub fn symbolize(&self, request: &mut SymbolizationRequest) -> anyhow::Result<()> {
+    pub async fn symbolize(&self, request: &mut SymbolizationRequest) -> anyhow::Result<()> {
         log::info!("Symbolizing request for build_id: {}", request.build_id);
 
         let build_id = &request.build_id;
 
         let mut dbginfo_md = {
-            let metadata = self.lock_metadata()?;
-            metadata
+            self.metadata
                 .fetch(build_id, &DebuginfoType::DebuginfoUnspecified)
                 .ok_or_else(|| {
                     Status::not_found(format!("Debuginfo for build_id {} not found", build_id))
@@ -79,7 +78,7 @@ impl Symbolizer {
         }
         let _ = Self::validate_source(&dbginfo_md);
 
-        let raw_data = self.fetcher.fetch_raw_elf(&dbginfo_md)?;
+        let raw_data = self.fetcher.fetch_raw_elf(&dbginfo_md).await?;
         let elf_debug_info = self.get_debug_info(&request.build_id, &mut dbginfo_md, &raw_data)?;
 
         let mut l = Liner::new(
@@ -143,14 +142,6 @@ impl Symbolizer {
         Ok(())
     }
 
-    fn lock_metadata(&self) -> anyhow::Result<MutexGuard<MetadataStore>> {
-        let m = self
-            .metadata
-            .lock()
-            .map_err(|_| Status::internal("Failed to lock metadata store"))?;
-        Ok(m)
-    }
-
     fn create_and_write_temp_file(&self, data: &[u8], build_id: &str) -> anyhow::Result<PathBuf> {
         let mut tmp_file = tempfile::NamedTempFile::new_in(&self.temp_dir)
             .map_err(|e| Status::internal(format!("Failed to create temporary file: {}", e)))?;
@@ -172,8 +163,8 @@ impl Symbolizer {
     }
 
     fn update_quality(&self, build_id: &str, quality: DebuginfoQuality) -> anyhow::Result<()> {
-        let mut metadata = self.lock_metadata()?;
-        metadata.set_quality(build_id, &quality, &DebuginfoType::DebuginfoUnspecified)?;
+        self.metadata
+            .set_quality(build_id, &quality, &DebuginfoType::DebuginfoUnspecified)?;
         Ok(())
     }
 
@@ -245,17 +236,20 @@ impl Symbolizer {
 
 #[cfg(test)]
 mod tests {
-    use crate::{debuginfo_store, metapb, profile};
+
+    use object_store::ObjectStore;
+
+    use crate::{debuginfo_store, metapb, profile, storage};
 
     use super::*;
 
     #[test]
     fn symbolization_test() {
-        let metadata_store = Arc::new(Mutex::new(debuginfo_store::MetadataStore::new()));
+        let metadata_store = debuginfo_store::MetadataStore::new();
         let debuginfod = Arc::new(Mutex::new(debuginfo_store::DebugInfod::default()));
-        let bucket: Arc<Mutex<HashMap<String, Vec<u8>>>> = Arc::new(Mutex::from(HashMap::new()));
+        let bucket: Arc<dyn ObjectStore> = Arc::new(storage::new_memory_bucket());
         let symbolizer = Arc::new(Symbolizer::new(
-            Arc::clone(&metadata_store),
+            debuginfo_store::MetadataStore::with_store(metadata_store.store.clone()),
             DebuginfoFetcher::new(Arc::clone(&bucket), Arc::clone(&debuginfod)),
         ));
 


### PR DESCRIPTION
- switch to arrow2 for faster write operations and chunking
- switch Hashmap for actual Cache store with LRU eviction policy
- switch Hashmap for object storage (currently in memory but can be swapped for any obj storage provider)