### PR TITLE
Migrate from Arrow2 to arrow

### DIFF
--- a/src/columnquery/mod.rs
+++ b/src/columnquery/mod.rs
@@ -80,9 +80,9 @@ mod tests {
                 .unwrap(),
         );
         let column_query = ColumnQuery::new(&dal);
-        let qs = "arch=aarch64,node=focal|parca_agent_cpu:samples:count:cpu:nanoseconds";
+        let qs = "arch=aarch64|parca_agent_cpu:samples:count:cpu:nanoseconds";
         let x = column_query
-            .query(ColumnQueryRequest::GeneratePprof, qs, 0)
+            .query(ColumnQueryRequest::GeneratePprof, qs, 1734496813872)
             .await
             .unwrap();
     }

--- a/src/profile/utils.rs
+++ b/src/profile/utils.rs
@@ -184,7 +184,7 @@ pub async fn symbolize_locations(
             }],
         };
 
-        symbolizer.symbolize(&mut sym_req).await?;
+        let _ = symbolizer.symbolize(&mut sym_req).await;
 
         // Update result_locations directly from the symbolized locations
         for (idx, loc) in locations_with_indices.iter() {

--- a/src/schema_builder.rs
+++ b/src/schema_builder.rs
@@ -3,64 +3,60 @@ use std::sync::Arc;
 
 //TODO: Add PprofLocationsArrowSchemaHere
 //
+//
+
+pub fn locations_inner_field() -> Vec<Field> {
+    vec![
+        Field::new("address", DataType::UInt64, true),
+        Field::new("mapping_start", DataType::UInt64, true),
+        Field::new("mapping_limit", DataType::UInt64, true),
+        Field::new("mapping_offset", DataType::UInt64, true),
+        Field::new(
+            "mapping_file",
+            DataType::Dictionary(Box::new(DataType::Int32), Box::new(DataType::Binary)),
+            true,
+        ),
+        Field::new(
+            "mapping_build_id",
+            DataType::Dictionary(Box::new(DataType::Int32), Box::new(DataType::Binary)),
+            true,
+        ),
+        Field::new(
+            "lines",
+            DataType::List(Arc::new(Field::new(
+                "lines_inner",
+                DataType::Struct(Fields::from(vec![
+                    Field::new("line", DataType::Int64, true),
+                    Field::new(
+                        "function_name",
+                        DataType::Dictionary(Box::new(DataType::Int32), Box::new(DataType::Binary)),
+                        true,
+                    ),
+                    Field::new(
+                        "function_system_name",
+                        DataType::Dictionary(Box::new(DataType::Int32), Box::new(DataType::Binary)),
+                        true,
+                    ),
+                    Field::new(
+                        "function_filename",
+                        DataType::Dictionary(Box::new(DataType::Int32), Box::new(DataType::Binary)),
+                        true,
+                    ),
+                    Field::new("function_start_line", DataType::Int64, true),
+                ])),
+                true,
+            ))),
+            true,
+        ),
+    ]
+}
 
 pub fn locations_field() -> Field {
     Field::new(
         "locations",
         DataType::List(Arc::new(Field::new(
-            "locations_inner",
-            DataType::Struct(Fields::from(vec![
-                Field::new("address", DataType::UInt64, true),
-                Field::new("mapping_start", DataType::UInt64, true),
-                Field::new("mapping_limit", DataType::UInt64, true),
-                Field::new("mapping_offset", DataType::UInt64, true),
-                Field::new(
-                    "mapping_file",
-                    DataType::Dictionary(Box::new(DataType::UInt32), Box::new(DataType::Binary)),
-                    true,
-                ),
-                Field::new(
-                    "mapping_build_id",
-                    DataType::Dictionary(Box::new(DataType::UInt32), Box::new(DataType::Binary)),
-                    true,
-                ),
-                Field::new(
-                    "lines",
-                    DataType::List(Arc::new(Field::new(
-                        "lines_inner",
-                        DataType::Struct(Fields::from(vec![
-                            Field::new("line", DataType::Int64, true),
-                            Field::new(
-                                "function_name",
-                                DataType::Dictionary(
-                                    Box::new(DataType::UInt32),
-                                    Box::new(DataType::Binary),
-                                ),
-                                true,
-                            ),
-                            Field::new(
-                                "function_system_name",
-                                DataType::Dictionary(
-                                    Box::new(DataType::UInt32),
-                                    Box::new(DataType::Binary),
-                                ),
-                                true,
-                            ),
-                            Field::new(
-                                "function_filename",
-                                DataType::Dictionary(
-                                    Box::new(DataType::UInt32),
-                                    Box::new(DataType::Binary),
-                                ),
-                                true,
-                            ),
-                            Field::new("function_start_line", DataType::Int64, true),
-                        ])),
-                        true,
-                    ))),
-                    true,
-                ),
-            ])),
+            "item",
+            DataType::Struct(Fields::from(locations_inner_field())),
             true,
         ))),
         true,

--- a/src/symbolizer/mod.rs
+++ b/src/symbolizer/mod.rs
@@ -66,7 +66,10 @@ impl Symbolizer {
             self.metadata
                 .fetch(build_id, &DebuginfoType::DebuginfoUnspecified)
                 .ok_or_else(|| {
-                    Status::not_found(format!("Debuginfo for build_id {} not found", build_id))
+                    Status::not_found(format!(
+                        "Debuginfo Metadata for build_id {} not found",
+                        build_id
+                    ))
                 })?
                 .clone()
         };

--- a/src/symbols/addr_to_line/symbol.rs
+++ b/src/symbols/addr_to_line/symbol.rs
@@ -168,6 +168,5 @@ mod tests {
         let x = l
             .pc_to_lines(NormalizedAddress(0x0000000000041290))
             .unwrap();
-        println!("{:?}", x);
     }
 }


### PR DESCRIPTION
Maintain consistency in arrow implementation. Use arrow because datafusion, our chosen query engine, already ships arrow with it.